### PR TITLE
Adds Sass-style comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,16 @@ Enter the shortcut `com-long` followed by the `tab` key
 #### Todo List Comment Usage
 
 Enter the shortcut `com-todo` followed by the `tab` key
+
+
+### Sass-style Comments
+
+Each of the comment-types listed above can be rendered in the form of a Sass-style comment using the shortcuts listed below.
+
+* Basic Comment (Sass) - `scom-basic`
+* Section Comment (Sass) - `scom-section`
+* Sub-Section Comment (Sass) - `scom-sub`
+* Long Comment (Sass) - `scom-long`
+* Todo List Comment (Sass) - `scom-todo`
+
+As before, each shortcut should be followed by the `tab` key.

--- a/sass-basic-comment.sublime-snippet
+++ b/sass-basic-comment.sublime-snippet
@@ -3,6 +3,6 @@
 // ${1}
 
 ]]></content>
-	<tabTrigger>scom-basic</tabTrigger>
+	<tabTrigger>com-sass-basic</tabTrigger>
 	<description>Idiomatic CSS - (Sass) Basic Comment</description>
 </snippet>

--- a/sass-basic-comment.sublime-snippet
+++ b/sass-basic-comment.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+	<content><![CDATA[
+// ${1}
+
+]]></content>
+	<tabTrigger>scom-basic</tabTrigger>
+	<description>Idiomatic CSS - (Sass) Basic Comment</description>
+</snippet>

--- a/sass-long-comment.sublime-snippet
+++ b/sass-long-comment.sublime-snippet
@@ -5,6 +5,6 @@
 //
 
 ]]></content>
-	<tabTrigger>scom-long</tabTrigger>
+	<tabTrigger>com-sass-long</tabTrigger>
 	<description>Idiomatic CSS - (Sass) Longer Descriptor Comment</description>
 </snippet>

--- a/sass-long-comment.sublime-snippet
+++ b/sass-long-comment.sublime-snippet
@@ -1,0 +1,10 @@
+<snippet>
+	<content><![CDATA[
+//
+// ${1}
+//
+
+]]></content>
+	<tabTrigger>scom-long</tabTrigger>
+	<description>Idiomatic CSS - (Sass) Longer Descriptor Comment</description>
+</snippet>

--- a/sass-section-comment-block.sublime-snippet
+++ b/sass-section-comment-block.sublime-snippet
@@ -1,0 +1,12 @@
+<snippet>
+	<content><![CDATA[
+// ==========================================================================
+// ${1}
+// ==========================================================================
+
+${2}
+
+]]></content>
+	<tabTrigger>scom-section</tabTrigger>
+	<description>Idiomatic CSS - (Sass) Section Comment Block</description>
+</snippet>

--- a/sass-section-comment-block.sublime-snippet
+++ b/sass-section-comment-block.sublime-snippet
@@ -7,6 +7,6 @@
 ${2}
 
 ]]></content>
-	<tabTrigger>scom-section</tabTrigger>
+	<tabTrigger>com-sass-section</tabTrigger>
 	<description>Idiomatic CSS - (Sass) Section Comment Block</description>
 </snippet>

--- a/sass-sub-section-comment-block.sublime-snippet
+++ b/sass-sub-section-comment-block.sublime-snippet
@@ -1,0 +1,12 @@
+<snippet>
+	<content><![CDATA[
+//
+// ${1}
+// ==========================================================================
+
+${2}
+
+]]></content>
+	<tabTrigger>scom-sub</tabTrigger>
+	<description>Idiomatic CSS - (Sass) Sub-Section Comment Block</description>
+</snippet>

--- a/sass-sub-section-comment-block.sublime-snippet
+++ b/sass-sub-section-comment-block.sublime-snippet
@@ -7,6 +7,6 @@
 ${2}
 
 ]]></content>
-	<tabTrigger>scom-sub</tabTrigger>
+	<tabTrigger>com-sass-sub</tabTrigger>
 	<description>Idiomatic CSS - (Sass) Sub-Section Comment Block</description>
 </snippet>

--- a/sass-todo-comment.sublime-snippet
+++ b/sass-todo-comment.sublime-snippet
@@ -1,0 +1,13 @@
+<snippet>
+	<content><![CDATA[
+//
+// TODO 
+// ${1}
+//
+
+${2}
+
+]]></content>
+	<tabTrigger>scom-todo</tabTrigger>
+	<description>Idiomatic CSS - (Sass) Todo Comment</description>
+</snippet>

--- a/sass-todo-comment.sublime-snippet
+++ b/sass-todo-comment.sublime-snippet
@@ -8,6 +8,6 @@
 ${2}
 
 ]]></content>
-	<tabTrigger>scom-todo</tabTrigger>
+	<tabTrigger>com-sass-todo</tabTrigger>
 	<description>Idiomatic CSS - (Sass) Todo Comment</description>
 </snippet>


### PR DESCRIPTION
TLDR; resolve #5 

As per the open issues, I discovered that I was not the only user of this Package who would prefer the option to use it with Sass-style comments.

(For clarity's sake, Sass-style comments are single-line and are removed from CSS output.)

Contained in this PR are snippets for Sass-style comments that mirror each of the original snippet contributions, as well as a small documentation update describing their usage.
